### PR TITLE
remove redundant attr_writer

### DIFF
--- a/lib/ark/configurable.rb
+++ b/lib/ark/configurable.rb
@@ -1,7 +1,6 @@
 module Ark
   module Configurable
     attr_accessor :ip, :port, :nethash, :version
-    attr_writer :ip, :port, :nethash, :version
 
     class << self
       def keys


### PR DESCRIPTION
Hi there,

I am new to Ark and am taking a look at this repo to see if there is any way I can contribute.  In my initial review I noticed that there was a redundant attr_writer.  It seems like that is unnecessary since there is already an attr_accessor defined for those attributes.  Are there any particular areas of the code I can take a look at to contribute or new features that are needed for this repo?