### PR TITLE
use equal instead of semicolon to assign parameters

### DIFF
--- a/lib/ark/client/block.rb
+++ b/lib/ark/client/block.rb
@@ -5,7 +5,7 @@ module Ark
         get('api/blocks/get', {:id => id})
       end
 
-      def blocks(parameters: {})
+      def blocks(parameters = {})
         get('api/blocks', parameters)
       end
 

--- a/lib/ark/client/delegate.rb
+++ b/lib/ark/client/delegate.rb
@@ -5,19 +5,19 @@ module Ark
         get('api/delegates/count')
       end
 
-      def search_delegates(q, parameters: {})
+      def search_delegates(q, parameters = {})
         get('api/delegates/search', {q: q}.merge(parameters))
       end
 
-      def delegate_voters(publicKey, parameters: {})
+      def delegate_voters(publicKey, parameters = {})
         get('api/delegates/voters', {publicKey: publicKey}.merge(parameters))
       end
 
-      def delegate(parameters: {})
+      def delegate(parameters = {})
         get('api/delegates/get', parameters)
       end
 
-      def delegates(parameters: {})
+      def delegates(parameters = {})
         get('api/delegates', parameters)
       end
 
@@ -29,7 +29,7 @@ module Ark
         get('api/delegates/forging/getForgedByAccount', {generatorPublicKey: generatorPublicKey})
       end
 
-      def create_delegate(secret, username, secondSecret: nil)
+      def create_delegate(secret, username, secondSecret = nil)
         transaction = buildTransaction(
           'delegate.createDelegate', {
             :secret => secret,
@@ -40,7 +40,7 @@ module Ark
         post('peer/transactions', {:transactions => [transaction]})
       end
 
-      def vote_for_delegate(secret, delegates, secondSecret: nil)
+      def vote_for_delegate(secret, delegates, secondSecret = nil)
         transaction = buildTransaction(
           'vote.createVote', {
             :secret => secret,
@@ -55,15 +55,15 @@ module Ark
         get('api/delegates/getNextForgers')
       end
 
-      def enable_forging(secret, parameters: {})
+      def enable_forging(secret, parameters = {})
         post('api/delegates/forging/enable', {:secret => secret}.merge(parameters))
       end
 
-      def disable_forging(secret, parameters: {})
+      def disable_forging(secret, parameters = {})
         post('api/delegates/forging/disable', {:secret => secret}.merge(parameters))
       end
 
-      def forging_status(publicKey, parameters: {})
+      def forging_status(publicKey, parameters = {})
         post('api/delegates/forging/disable', {:publicKey => publicKey}.merge(parameters))
       end
     end

--- a/lib/ark/client/multisignature.rb
+++ b/lib/ark/client/multisignature.rb
@@ -5,7 +5,7 @@ module Ark
         get('api/multisignatures/pending', {:publicKey => publicKey})
       end
 
-      def multi_signature_sign(transactionId, secret, parameters: {})
+      def multi_signature_sign(transactionId, secret, parameters = {})
         post('api/multisignatures/sign', {:transactionId => transactionId, :secret => secret}.merge(parameters))
       end
 

--- a/lib/ark/client/peer.rb
+++ b/lib/ark/client/peer.rb
@@ -5,7 +5,7 @@ module Ark
         get('api/peers/get', {:ip => ip, :port => port})
       end
 
-      def peers(parameters: {})
+      def peers(parameters = {})
         get('api/peers', parameters)
       end
 

--- a/lib/ark/client/transaction.rb
+++ b/lib/ark/client/transaction.rb
@@ -5,7 +5,7 @@ module Ark
         get('api/transactions/get', {:id => id})
       end
 
-      def transactions(parameters: {})
+      def transactions(parameters = {})
         get('api/transactions', parameters)
       end
 
@@ -13,7 +13,7 @@ module Ark
         get('api/transactions/unconfirmed/get', {:id => id})
       end
 
-      def unconfirmed_transactions(parameters: {})
+      def unconfirmed_transactions(parameters = {})
         get('api/transactions/unconfirmed', parameters)
       end
 


### PR DESCRIPTION
Hi there,

I am rails developer and one of my client want to use ark API. so I have looked into it and there is a small mistake done in methods. It needs to use equal instead of semicolon to pass parameters in a function. I have replaced with it and verified at my end.